### PR TITLE
External URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ This repository contains the **source code** of the official App registry for th
             "authors": "A. Person, B. Smart",
             "logo": "folder/logo.png",
             "state": "development",
-            "documentation_url": "https://aiidalab-exmpl.readthedocs.io"
+            "documentation_url": "https://aiidalab-exmpl.readthedocs.io",
+            "external_url": "http://www.aiida.net"
         }
     ```
 
@@ -83,6 +84,10 @@ One of
 
 The link to the online documentation of the app (e.g. on
 [Read The Docs](https://readthedocs.org/)).
+
+#### external_url
+
+General homepage for your app.
 
 ## Acknowledgements
 

--- a/make_ghpages/mod/templates/singlepage.html
+++ b/make_ghpages/mod/templates/singlepage.html
@@ -15,13 +15,19 @@
     <h2>General information</h2>
     <div>
         <p>
-            <a href="{{ git_url }}" target="_blank">Go to the app code homepage</a> 
+            <strong>App code</strong>: <a href="{{ git_url }}" target="_blank">Go to the app code</a> 
         </p>
     </div>
 
-    {% if documentation_url %}
+    {% if metainfo.external_url %}
         <p>
-            <strong>Documentation</strong>: <a href="{{ documentation_url }}" target="_blank">Go to app documentation</a>
+            <strong>App homepage</strong>: <a href="{{ metainfo.external_url }}" target="_blank">Go to app homepage</a>
+        <p>
+    {% endif %}
+
+    {% if metainfo.documentation_url %}
+        <p>
+            <strong>Documentation</strong>: <a href="{{ metainfo.documentation_url }}" target="_blank">Go to app documentation</a>
         <p>
     {% else %}
         <p>


### PR DESCRIPTION
#### External URL

Introduce the optional "external_url" key for `metadata.json` in app root folders.

External URL is an optional key, whose value should be a URL to the application's homepage.

For example, for the `aiidalab-aiida-tutorials` app the external URL may be:

```json
metadata.json:

{
    "external_url": "http://www.aiida.net",
    ...
}
```

#### Fixes

The documentation URL is now correctly retrieved for `singlepage.html`.

#### Minor changes

The link to the application's code homepage has been given a label prior to the link in `singlepage.html`.