### PR TITLE
remove doc url from index

### DIFF
--- a/make_ghpages/mod/templates/main_index.html
+++ b/make_ghpages/mod/templates/main_index.html
@@ -20,21 +20,14 @@
         {% if app.metainfo.description %}
         <p class=description>{{app.metainfo.description}}</p>
         {% endif %}
-        <p class="currentstate">Current state: {{ app.metainfo.state }}</p>
-        <p><a href="{{ app.git_url }}" target="_blank">app homepage</a> 
+        <p class="currentstate">State: {{ app.metainfo.state }} 
+          {% if app.metainfo.version %}(version {{ app.metainfo.version }}){% endif %}
+        </p>
+        <p><a href="{{ app.git_url }}" target="_blank">Source code</a> 
         {% if app.hosted_on %}
         <span style="font-size: 90%">(hosted on {{ app.hosted_on }})</span>
         {% endif %}
         </p>
-        {% if app.documentation_url %}
-            <p>
-                <strong>Documentation</strong>: <a href="{{ app.documentation_url }}" target="_blank">Go to app documentation</a>
-            <p>
-        {% else %}
-            <p>
-                <strong>Documentation</strong>: Documentation not provided by the app author
-            <p>
-        {% endif %}
         <!-- Summaryinfo has not yet been introduced to the AiiDA Lab app registry -->
         {% if app.summaryinfo %}
             <p class="summaryinfo">

--- a/make_ghpages/mod/templates/singlepage.html
+++ b/make_ghpages/mod/templates/singlepage.html
@@ -15,7 +15,7 @@
     <h2>General information</h2>
     <div>
         <p>
-            <strong>App code</strong>: <a href="{{ git_url }}" target="_blank">Go to the app code</a> 
+            <strong>Source code</strong>: <a href="{{ git_url }}" target="_blank">Go to the app source code</a> 
         </p>
     </div>
 


### PR DESCRIPTION
 + add version to index
 + rename "app homepage" to "source code"


Rationale: Since the doc url is currently empty for every app, there is no point in boasting about this in our index.
Furthermore, I think it's perfectly fine to first click on the app to see quickly what it is about, and then from there go to a documentation.