### PR TITLE
Validate logo URL and add pytests

### DIFF
--- a/.travis-data/deploy.sh
+++ b/.travis-data/deploy.sh
@@ -4,14 +4,9 @@ set -e # Exit with nonzero exit code if anything fails
 SOURCE_BRANCH="master"
 TARGET_BRANCH="gh-pages"
 
-#function doCompile {
-#  ./compile.sh
-#}
-
 # Pull requests and commits to other branches shouldn't try to deploy, just build to verify
 if [ "$TRAVIS_PULL_REQUEST" != "false" -o "$TRAVIS_BRANCH" != "$SOURCE_BRANCH" ]; then
-    echo "Skipping deploy; just doing a build."
-    # doCompile
+    echo "PR: Skipping deploy."
     exit 0
 fi
 

--- a/.travis-data/run_script.sh
+++ b/.travis-data/run_script.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# Exit with nonzero exit code if anything fails and be verbose
+set -ev
+
+# Set paths
+BUILD_PATH="${TRAVIS_BUILD_DIR}/make_ghpages"
+DEPLOY_PATH="${TRAVIS_BUILD_DIR}/.travis-data"
+
+# Make sure we're in the package root
+cd ${TRAVIS_BUILD_DIR}
+
+case "$RUN_TYPE" in
+    tests)
+        # Run pytest
+        pytest
+        ;;
+    build)
+        # Build pages
+        python "$BUILD_PATH/make_pages.py"
+
+        # Deploy
+        "$DEPLOY_PATH/deploy.sh"
+        ;;
+esac

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,20 +8,16 @@ cache: pip
 # We are using travis in order to build and deploy the page to the gh-pages branch.
 # Using encrypted deploy key as described here:
 # https://gist.github.com/domenic/ec8b0fc8ab45f39403dd#get-encrypted-credentials
-env: 
-  global: 
-  - ENCRYPTION_LABEL: "b78f01f07a2c"
-  - COMMIT_AUTHOR_EMAIL: deploy@travis-ci.org
+env:
+  - RUN_TYPE="tests"
+  - RUN_TYPE="build" ENCRYPTION_LABEL="b78f01f07a2c" COMMIT_AUTHOR_EMAIL="deploy@travis-ci.org"
 
 before_install:
-  - cd make_ghpages
   # Update pip, setuptools, and wheel
   - pip install -U pip setuptools wheel
 
 install:
   # Install needed dependencies
-  - pip install -r requirements.txt
+  - pip install -r ./make_ghpages/requirements.txt
 
-script: 
-  - python make_pages.py  
-  - cd ../.travis-data && ./deploy.sh
+script: .travis-data/run_script.sh

--- a/make_ghpages/exceptions.py
+++ b/make_ghpages/exceptions.py
@@ -1,6 +1,20 @@
 # -*- coding: utf-8 -*-
 
-class MissingMetadata(Exception):
+class MissingEntity(Exception):
+    """ Missing entity
+    Base exception for missing entities, usually URLs
+    """
+    pass
+
+
+class WrongEntity(Exception):
+    """ Wrong entity
+    Base exception for wrong entities
+    """
+    pass
+
+
+class MissingMetadata(MissingEntity):
     """ Missing metadata
     The key 'meta_url' is missing from apps.json or
     the value of 'meta_url' is wrong/missing.
@@ -8,7 +22,7 @@ class MissingMetadata(Exception):
     pass
 
 
-class WrongMetadata(Exception):
+class WrongMetadata(WrongEntity):
     """ Wrong metadata
     The provided metadata.json file cannot be loaded by Python's built-in json.loads method.
     The metadata.json file may not be a correct JSON file.
@@ -16,7 +30,7 @@ class WrongMetadata(Exception):
     pass
 
 
-class MissingGit(Exception):
+class MissingGit(MissingEntity):
     """ Missing git URL
     The key 'git_url' is missing from apps.json or
     the value of 'git_url' is wrong/missing.
@@ -24,7 +38,7 @@ class MissingGit(Exception):
     pass
 
 
-class MissingCategories(Exception):
+class MissingCategories(MissingEntity):
     """ Missing categories
     The key 'categories' is missing from apps.json or
     the value of 'categories' is wrong/missing.
@@ -32,8 +46,16 @@ class MissingCategories(Exception):
     pass
 
 
-class WrongCategory(Exception):
+class WrongCategory(WrongEntity):
     """ Wrong category
     The specified category does not exist in categories.json.
+    """
+    pass
+
+
+class MissingLogo(MissingEntity):
+    """ Missing logo
+    Having retrieved the URL for the logo (from metadata.json),
+    it is now found that the logo does not exist on the given URL.
     """
     pass

--- a/make_ghpages/make_pages.py
+++ b/make_ghpages/make_pages.py
@@ -118,6 +118,12 @@ def validate_categories(categories, raw_data):
 def get_logo_url(logo_rel_path, meta_url):
     logo_url = meta_url[:-len('metadata.json')] + logo_rel_path
 
+    # Validate url to logo
+    try:
+        urlopen(logo_url, timeout=TIMEOUT_SECONDS)
+    except Exception:
+        raise exc.MissingLogo("Value for 'logo' in your app's metadata.json may be wrong: '{}'".format(logo_url))
+
     return logo_url
 
 

--- a/make_ghpages/requirements.txt
+++ b/make_ghpages/requirements.txt
@@ -1,2 +1,3 @@
 dulwich
 jinja2
+pytest

--- a/make_ghpages/test_make_pages.py
+++ b/make_ghpages/test_make_pages.py
@@ -1,0 +1,95 @@
+# -*- coding: utf-8 -*-
+
+import pytest
+import os
+import json
+
+import exceptions as exc
+import make_pages as mp
+
+TEST_GIT_URL = "https://github.com/aiidalab/aiidalab-registry"
+
+### UTILITY FUNCTIONS ###
+def setup_apps_json(tmpdir):
+    """ Setup apps.json file
+    Create artificial apps.json file
+    """
+    apps_json = {
+        "test": {
+            "git_url": TEST_GIT_URL,
+            "meta_url": "file://{}".format(os.path.join(tmpdir, 'metadata.json')),
+            "categories": ["utilities"]
+        }
+    }
+    return apps_json
+
+
+def write_json_files(tmpdir, metadata=None, apps=None):
+    """Write JSON files to tmpdir"""
+    if not metadata:
+        metadata = {}
+
+    if not apps:
+        apps = setup_apps_json(tmpdir)
+
+    with open(os.path.join(tmpdir, 'metadata.json'), 'w') as fp:
+        json.dump(metadata, fp)
+    
+    with open(os.path.join(tmpdir, 'apps.json'), 'w') as fp:
+        json.dump(apps, fp)
+
+
+### TESTS ###
+def test_validate_logo(tmpdir):
+    """ Test validate logo in get_logo_url(logo_rel_path, meta_url)
+    Make sure exception is raised when logo URL is present,
+    but points to a non-existent location.
+    """
+    # Setup
+    metadata_test = {
+        "logo": "img/test.png"  # Non-existent file
+    }
+
+    write_json_files(tmpdir, metadata=metadata_test)
+
+    # Test
+    with pytest.raises(exc.MissingLogo):
+        # Load apps.json
+        with open(os.path.join(tmpdir, 'apps.json')) as fp:
+            app_raw_data = json.load(fp)
+        app_data = app_raw_data['test']
+
+        # Load metadata.json (similarly to make_pages.py)
+        meta_info = mp.get_meta_info(app_data['meta_url'])
+        app_data['metainfo'] = mp.validate_meta_info('test', meta_info, app_data['git_url'])
+
+        # Get logo URL
+        app_data['logo'] = mp.get_logo_url(app_data['metainfo']['logo'], app_data['meta_url'])
+
+
+def test_get_logo_url(tmpdir):
+    """ Test get_logo_url(logo_rel_path, meta_url)
+    Making path to logo equal to path to metadata.json to test path to "logo"
+    is correctly found.
+    """
+    # Setup
+    metadata_test = {
+        "logo": "metadata.json"  # While not image, still valid path
+    }
+
+    write_json_files(tmpdir, metadata=metadata_test)
+
+    # Test
+    # Load apps.json
+    with open(os.path.join(tmpdir, 'apps.json')) as fp:
+        app_raw_data = json.load(fp)
+    app_data = app_raw_data['test']
+
+    # Load metadata.json (similarly to make_pages.py)
+    meta_info = mp.get_meta_info(app_data['meta_url'])
+    app_data['metainfo'] = mp.validate_meta_info('test', meta_info, app_data['git_url'])
+
+    # Get logo URL
+    app_data['logo'] = mp.get_logo_url(app_data['metainfo']['logo'], app_data['meta_url'])
+
+    assert app_data['logo'] == app_data['meta_url']


### PR DESCRIPTION
Checks that the URL created from the value of "logo" in an app's `metadata.json` can be reached/is valid.

Add `pytest` tests that are also run by Travis (currently testing this).

**Note**: The latter is perhaps not necessary, but also doesn't hurt. I have done it mainly to learn `pytest` and how to interact with Travis. Can always remove the tests but keep in the logo validation part.