### PR TITLE
try fixing run_script

### DIFF
--- a/.travis-data/run_script.sh
+++ b/.travis-data/run_script.sh
@@ -20,6 +20,8 @@ case "$RUN_TYPE" in
         python "$BUILD_PATH/make_pages.py"
 
         # Deploy
-        "$DEPLOY_PATH/deploy.sh"
+        cd $DEPLOY_PATH
+        "./deploy.sh"
+        cd -
         ;;
 esac


### PR DESCRIPTION
./deploy.sh must be called from the directory where it is located.

All deploys since 8b99859a15e768f80024b07e7304f61140007661 have failed
due to this.