### PR TITLE
Remove backup app.

### DIFF
--- a/apps.json
+++ b/apps.json
@@ -39,11 +39,6 @@
         "meta_url": "https://raw.githubusercontent.com/aiidalab/aiidalab-units/master/metadata.json",
         "categories": ["utilities"]
     },
-    "backup": {
-        "git_url": "https://github.com/aiidalab/aiidalab-backup",
-        "meta_url": "https://raw.githubusercontent.com/aiidalab/aiidalab-backup/master/metadata.json",
-        "categories": ["utilities"]
-    },
     "calcexamples": {
         "git_url": "https://github.com/aiidalab/aiidalab-calculation-examples.git",
         "meta_url": "https://raw.githubusercontent.com/aiidalab/aiidalab-calculation-examples/master/metadata.json",


### PR DESCRIPTION
The app was copying the user's home folder to the daint supercomputer. 
This is too specific and can't be generalized at the current state of things.
Moreover, the home drive of AiiDA lab users is backed up anyways.