### PR TITLE
Delete epfl and cscs apps:

### DIFF
--- a/apps.json
+++ b/apps.json
@@ -9,16 +9,6 @@
         "meta_url": "https://raw.githubusercontent.com/aiidalab/aiidalab-aiida-cockpit/master/metadata.json",
         "categories": ["setup", "utilities"]
     },
-    "cscs": {
-        "git_url": "https://github.com/aiidalab/aiidalab-cscs",
-        "meta_url": "https://raw.githubusercontent.com/aiidalab/aiidalab-cscs/master/metadata.json",
-        "categories": ["setup"]
-    },
-    "epfl": {
-        "git_url": "https://github.com/aiidalab/aiidalab-epfl-supercomputers",
-        "meta_url": "https://raw.githubusercontent.com/aiidalab/aiidalab-epfl-supercomputers/master/metadata.json",
-        "categories": ["setup"]
-    },
     "nanoribbons": {
         "git_url": "https://github.com/nanotech-empa/aiidalab-empa-nanoribbons",
         "meta_url": "https://raw.githubusercontent.com/nanotech-empa/aiidalab-empa-nanoribbons/master/metadata.json",


### PR DESCRIPTION
Those two apps were used to setup daint computer (cscs) and fidis/deneb
computers (epfl) and quantum codes installed there. In my opinion, there
is no point in making app per organization. The computer setup has been
generalized by aiidalab-widgets-base and can be extended by creating a
registry of available computers.

The code setup, in turn, is quite hard to maintain because they get
updated from time to time and to date, there is no automatic way to cope
with those updates.