### PR TITLE
Remove persistence homology app from the registry.

### DIFF
--- a/apps.json
+++ b/apps.json
@@ -54,11 +54,6 @@
         "meta_url": "https://raw.githubusercontent.com/aiidalab/aiidalab-quantum-mobile/master/metadata.json",
         "categories": ["setup"]
     },
-    "persistence-homology": {
-        "git_url": "https://github.com/aiidalab/aiidalab-persistence-homology.git",
-        "meta_url": "https://raw.githubusercontent.com/aiidalab/aiidalab-persistence-homology/master/metadata.json",
-        "categories": ["classical"]
-    },
     "aiidalab-widgets-base": {
         "git_url": "https://github.com/aiidalab/aiidalab-widgets-base.git",
         "meta_url": "https://raw.githubusercontent.com/aiidalab/aiidalab-widgets-base/master/metadata.json",


### PR DESCRIPTION
fixes #36 

The app has been merged with aiidalab-epfl-lsmo, see the PR:
https://github.com/lsmo-epfl/aiidalab-epfl-lsmo/pull/8