### PR TITLE
Remove the vasp-example app from the registry.

### DIFF
--- a/apps.json
+++ b/apps.json
@@ -59,11 +59,6 @@
         "meta_url": "https://raw.githubusercontent.com/aiidalab/aiidalab-widgets-base/master/metadata.json",
         "categories": ["utilities"]
     },
-    "vasp-example": {
-        "git_url": "https://github.com/DropD/mc-vasp-example.git",
-        "meta_url": "https://raw.githubusercontent.com/DropD/mc-vasp-example/master/metadata.json",
-        "categories": ["quantum"]
-    },
     "aiidalab-optimade": {
         "git_url": "https://github.com/aiidalab/aiidalab-optimade.git",
         "meta_url": "https://raw.githubusercontent.com/aiidalab/aiidalab-optimade/master/metadata.json",


### PR DESCRIPTION
fixes #35 

The app is outdated and not maintained any longer.