### PR TITLE
(Temporarily) remove aiidalab-optimade

### DIFF
--- a/apps.json
+++ b/apps.json
@@ -29,11 +29,6 @@
         "meta_url": "https://raw.githubusercontent.com/lsmo-epfl/aiidalab-epfl-lsmo/master/metadata.json",
         "categories": ["classical", "quantum"]
     },
-    "aiidalab-optimade": {
-        "git_url": "https://github.com/aiidalab/aiidalab-optimade.git@aiidalab",
-        "meta_url": "https://raw.githubusercontent.com/aiidalab/aiidalab-optimade/aiidalab/metadata.json",
-        "categories": ["utilities"]
-    },
     "quantum-espresso": {
         "git_url": "https://github.com/aiidalab/aiidalab-qe.git",
         "meta_url": "https://raw.githubusercontent.com/aiidalab/aiidalab-qe/master/metadata.json",

--- a/apps.json
+++ b/apps.json
@@ -30,7 +30,7 @@
         "categories": ["classical", "quantum"]
     },
     "aiidalab-optimade": {
-        "git_url": "https://github.com/aiidalab/aiidalab-optimade.git",
+        "git_url": "https://github.com/aiidalab/aiidalab-optimade.git@aiidalab",
         "meta_url": "https://raw.githubusercontent.com/aiidalab/aiidalab-optimade/master/metadata.json",
         "categories": ["utilities"]
     },


### PR DESCRIPTION
~According to the "offline" determined system of how to report release sources, I have updated the `aiidalab-optimade` app's `git_url` value, specifying the branch to be used by default.~

Update: This PR will be changed to temporarily remove the `aiidalab-optimade` application. It will be reinstated once a repository re-factoring has happened.