### PR TITLE
Fix the link to metadata.json file of OPTIMADE app.

### DIFF
--- a/apps.json
+++ b/apps.json
@@ -31,7 +31,7 @@
     },
     "aiidalab-optimade": {
         "git_url": "https://github.com/aiidalab/aiidalab-optimade.git",
-        "meta_url": "https://raw.githubusercontent.com/aiidalab/aiidalab-optimade/master/metadata.json",
+        "meta_url": "https://raw.githubusercontent.com/aiidalab/aiidalab-optimade/aiidalab/metadata.json",
         "categories": ["utilities"]
     },
     "quantum-espresso": {


### PR DESCRIPTION
The old link points to a non-existing file.