### PR TITLE
Add optional 'requires' key to app metadata.

### DIFF
--- a/schemas/metadata.schema.json
+++ b/schemas/metadata.schema.json
@@ -33,6 +33,12 @@
                 "external_url": {
                   "type": "string",
                   "format": "uri"
+                },
+                "requires": {
+                  "type": "object",
+                  "patternProperties": {
+                    ".*": {"$ref": "#/definitions/Requirements"}
+                  }
                 }
             },
             "required": [
@@ -40,6 +46,13 @@
                 "title"
             ],
             "title": "Welcome"
+        },
+        "Requirements": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "title": "Requirements"
         }
     }
 }


### PR DESCRIPTION
This change to the schema adds the `requires` key that app developers can use to publish their app requirements as part of the app metadata.