### PR TITLE
add empa tb-mfh app

### DIFF
--- a/apps.json
+++ b/apps.json
@@ -19,6 +19,11 @@
         "meta_url": "https://raw.githubusercontent.com/nanotech-empa/aiidalab-empa-scanning-probe/master/metadata.json",
         "categories": ["quantum"]
     },
+    "tb-mfh": {
+        "git_url": "https://github.com/nanotech-empa/aiidalab-empa-tb-mfh",
+        "meta_url": "https://raw.githubusercontent.com/nanotech-empa/aiidalab-empa-tb-mfh/master/metadata.json",
+        "categories": ["quantum"]
+    },
     "aiidalab-widgets-base": {
         "git_url": "https://github.com/aiidalab/aiidalab-widgets-base.git",
         "meta_url": "https://raw.githubusercontent.com/aiidalab/aiidalab-widgets-base/master/metadata.json",


### PR DESCRIPTION
Hi, we developed a simple app to run tight-binding mean-field Hubbard calculations and would like to add it to the registry.