### PR TITLE
Test all available schemas within one test.

### DIFF
--- a/tests/test_validate_schemas.py
+++ b/tests/test_validate_schemas.py
@@ -1,4 +1,5 @@
 import re
+from dataclasses import asdict
 from pathlib import Path
 
 import jsonschema
@@ -24,20 +25,9 @@ def valid_categories(categories_yaml):
     return set(categories_yaml)
 
 
-def test_validate_schema_apps(schemas):
-    jsonschema.Draft7Validator.check_schema(schemas.apps)
-
-
-def test_validate_schemas_apps_meta(schemas):
-    jsonschema.Draft7Validator.check_schema(schemas.apps_meta)
-
-
-def test_validate_schemas_categories(schemas):
-    jsonschema.Draft7Validator.check_schema(schemas.categories)
-
-
-def test_validate_schemas_metadata(schemas):
-    jsonschema.Draft7Validator.check_schema(schemas.metadata)
+def test_validate_schemas(schemas):
+    for schema in asdict(schemas).values():
+        jsonschema.Draft7Validator.check_schema(schema)
 
 
 @pytest.mark.usefixtures("mock_schema_endpoints")


### PR DESCRIPTION
Instead of one test per schema. Removes the need to modify the test
whenever a schema is added or removed.

The next couple PRs are going to introduce various new schemas which makes the test maintenance more cumbersome than necessary.