### PR TITLE
Reference json schemas from the master branch.

### DIFF
--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,5 +1,5 @@
 CacheControl==0.12.6
-Jinja2==2.11.2
+Jinja2==2.11.3
 dacite==1.6.0
 dulwich==0.20.15
 jsonref==0.2

--- a/src/static/api/openapi-v1.yaml
+++ b/src/static/api/openapi-v1.yaml
@@ -15,7 +15,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: https://aiidalab.github.io/aiidalab-registry/schemas/v1/apps_index.schema.json#/definitions/AppsAndCategories
+                $ref: https://raw.githubusercontent.com/aiidalab/aiidalab-registry/master/src/static/schemas/v1/apps_index.schema.json#/definitions/AppsAndCategories
   /api/v1/apps/{appId}.json:
     parameters:
     - name: appId
@@ -33,7 +33,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: https://aiidalab.github.io/aiidalab-registry/schemas/v1/app.schema.json#/definitions/App
+                $ref: https://raw.githubusercontent.com/aiidalab/aiidalab-registry/master/src/static/schemas/v1/app.schema.json#/definitions/App
   /apps_meta.json:
     get:
       deprecated: true
@@ -44,4 +44,4 @@ paths:
           content:
             application/json:
               schema:
-                $ref: https://aiidalab.github.io/aiidalab-registry/schemas/v1/apps_meta.schema.json#/definitions/Welcome
+                $ref: https://raw.githubusercontent.com/aiidalab/aiidalab-registry/master/src/static/schemas/v1/apps_meta.schema.json#/definitions/Welcome

--- a/src/static/schemas/v1/app.schema.json
+++ b/src/static/schemas/v1/app.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://aiidalab.github.io/aiidalab-registry/schemas/v1/app.schema.json",
+    "$id": "https://raw.githubusercontent.com/aiidalab/aiidalab-registry/master/src/static/schemas/v1/app.schema.json",
     "$ref": "#/definitions/App",
     "definitions": {
         "App": {
@@ -20,7 +20,7 @@
                     ]
                 },
                 "metadata": {
-                    "$ref": "https://aiidalab.github.io/aiidalab-registry/schemas/v1/metadata.schema.json#/definitions/Welcome"
+                    "$ref": "metadata.schema.json#/definitions/Welcome"
                 },
                 "name": {
                     "type": "string"
@@ -49,7 +49,7 @@
         "Release": {
             "properties": {
                 "environment": {
-                    "$ref": "https://aiidalab.github.io/aiidalab-registry/schemas/v1/environment.schema.json#/definitions/Environment"
+                    "$ref": "environment.schema.json#/definitions/Environment"
                 },
                 "url": {
                     "type": "string"

--- a/src/static/schemas/v1/apps.schema.json
+++ b/src/static/schemas/v1/apps.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://aiidalab.github.io/aiidalab-registry/schemas/v1/apps.schema.json",
+    "$id": "https://raw.githubusercontent.com/aiidalab/aiidalab-registry/master/src/static/schemas/v1/apps.schema.json",
     "$ref": "#/definitions/Apps",
     "definitions": {
         "App": {
@@ -17,7 +17,7 @@
                     "format": "uri"
                 },
                 "metadata": {
-                    "$ref": "https://aiidalab.github.io/aiidalab-registry/schemas/v1/metadata.schema.json#/definitions/Welcome"
+                    "$ref": "metadata.schema.json#/definitions/Welcome"
                 },
                 "releases": {
                     "$ref": "#definitions/ReleaseSpecifications"
@@ -48,7 +48,7 @@
             "type": "object",
             "properties": {
                 "environment": {
-                    "$ref": "https://aiidalab.github.io/aiidalab-registry/schemas/v1/environment.schema.json#definitions/Environment"
+                    "$ref": "environment.schema.json#definitions/Environment"
                 },
                 "url": {
                     "$ref": "#definitions/ReleaseSpecificationUrl"

--- a/src/static/schemas/v1/apps_index.schema.json
+++ b/src/static/schemas/v1/apps_index.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://aiidalab.github.io/aiidalab-registry/schemas/v1/apps_index.schema.json",
+    "$id": "https://raw.githubusercontent.com/aiidalab/aiidalab-registry/master/src/static/schemas/v1/apps_index.schema.json",
     "$ref": "#/definitions/AppsAndCategories",
     "definitions": {
         "AppsAndCategories": {
@@ -55,7 +55,7 @@
             "additionalProperties": false,
             "patternProperties": {
                 ".*": {
-                    "$ref": "https://aiidalab.github.io/aiidalab-registry/schemas/v1/categories.schema.json#/definitions/Category"
+                    "$ref": "categories.schema.json#/definitions/Category"
                 }
             }
         }

--- a/src/static/schemas/v1/apps_meta.schema.json
+++ b/src/static/schemas/v1/apps_meta.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://aiidalab.github.io/aiidalab-registry/schemas/v1/apps_meta.schema.json",
+    "$id": "https://raw.githubusercontent.com/aiidalab/aiidalab-registry/master/src/static/schemas/v1/apps_meta.schema.json",
     "$ref": "#/definitions/Welcome",
     "definitions": {
         "App": {
@@ -39,7 +39,7 @@
                     "type": "string"
                 },
                 "metainfo": {
-                    "$ref": "https://aiidalab.github.io/aiidalab-registry/schemas/v1/metadata.schema.json#/definitions/Welcome"
+                    "$ref": "metadata.schema.json#/definitions/Welcome"
                 },
                 "name": {
                     "type": "string"
@@ -87,7 +87,7 @@
             "additionalProperties": false,
             "patternProperties": {
                 ".*": {
-                    "$ref": "https://aiidalab.github.io/aiidalab-registry/schemas/v1/categories.schema.json#/definitions/Category"
+                    "$ref": "categories.schema.json#/definitions/Category"
                 }
             }
         },

--- a/src/static/schemas/v1/categories.schema.json
+++ b/src/static/schemas/v1/categories.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://aiidalab.github.io/aiidalab-registry/schemas/v1/categories.schema.json",
+    "$id": "https://raw.githubusercontent.com/aiidalab/aiidalab-registry/master/src/static/schemas/v1/categories.schema.json",
     "$ref": "#/definitions/Welcome",
     "definitions": {
         "Category": {

--- a/src/static/schemas/v1/environment.schema.json
+++ b/src/static/schemas/v1/environment.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://aiidalab.github.io/aiidalab-registry/schemas/v1/environment.schema.json",
+    "$id": "https://raw.githubusercontent.com/aiidalab/aiidalab-registry/master/src/static/schemas/v1/environment.schema.json",
     "$ref": "#/definitions/Environment",
     "definitions": {
         "Environment": {

--- a/src/static/schemas/v1/metadata.schema.json
+++ b/src/static/schemas/v1/metadata.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://aiidalab.github.io/aiidalab-registry/schemas/v1/metadata.schema.json",
+    "$id": "https://raw.githubusercontent.com/aiidalab/aiidalab-registry/master/src/static/schemas/v1/metadata.schema.json",
     "$ref": "#/definitions/Welcome",
     "definitions": {
         "Requirements": {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,7 +35,7 @@ def schemas(config):
 @pytest.fixture
 def mock_schema_endpoints(requests_mock):
     schemas_path = ROOT.joinpath("src/static/schemas")
-    schemas_endpoint = "https://aiidalab.github.io/aiidalab-registry/schemas"
+    schemas_endpoint = "https://raw.githubusercontent.com/aiidalab/aiidalab-registry/master/src/static/schemas"
     for schema in schemas_path.glob("**/*.schema.json"):
         endpoint = f"{schemas_endpoint}/{schema.relative_to(schemas_path)}"
         requests_mock.get(endpoint, text=schema.read_text())


### PR DESCRIPTION
Previously, the json schemas were referenced from GitHub pages, which
isn't optimal. Referencing the schemas require their presence
at the destination URL. This is not possible when schemas are just created
and GH pages containing them aren't yet generated. At the same time,
the master branch always contains schemas and, therefore, is a good reference point.