### PR TITLE
Mock schemas endpoints during build for deployment.

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,7 +33,7 @@ jobs:
 
     - name: Build GH pages
       run: |
-        python "${GITHUB_WORKSPACE}/src/build.py"
+        python "${GITHUB_WORKSPACE}/src/build.py" --mock-schemas-endpoints
         cp -r "${GITHUB_WORKSPACE}/src/build/html" ${{ runner.temp }}/
 
     - uses: actions/checkout@v2


### PR DESCRIPTION
To work-around the chicken and egg issue with publishing the schemas
as part of the deployment process.