### PR TITLE
fix link on app registry

### DIFF
--- a/src/mod/templates/base.html
+++ b/src/mod/templates/base.html
@@ -1,7 +1,7 @@
 <!doctype html>
 
 {% set app_registry_url = "http://aiidateam.github.io/aiida-registry" %}
-{% set aiidalab_url = "https://aiidalab.materialscloud.org" %}
+{% set aiidalab_url = "https://www.materialscloud.org/aiidalab" %}
 
 <html lang="en">
 


### PR DESCRIPTION
The word "AiiDAlab" linked to the MARVEL AiiDAlab instance instead of
the generic landing page explaining what the AiiDAlab is.