### PR TITLE
Remove overlap and update qe-app info

### DIFF
--- a/apps.yaml
+++ b/apps.yaml
@@ -44,25 +44,6 @@ nanoribbons:
 quantum-espresso:
   releases:
     - url: 'git+https://github.com/aiidalab/aiidalab-qe.git@master:v22.05.0^..'
-      metadata:
-        state: development
-    - url: 'git+https://github.com/aiidalab/aiidalab-qe.git@master:v20.11.0^..v22.05.0'
-      metadata:
-        categories:
-        - quantum
-        logo: https://aiidalab.github.io/aiidalab-qe/miscellaneous/logos/QE.jpg
-        title: Quantum ESPRESSO
-        authors: Carl Simon Adorf, Aliaksandr Yakutovich, Marnik Bercx
-        description: Perform Quantum ESPRESSO calculations
-        external_url: https://github.com/aiidalab/aiidalab-qe
-        documentation_url: https://github.com/aiidalab/aiidalab-qe#readme
-        state: development
-    - url: 'git+https://github.com/aiidalab/aiidalab-qe.git@master:v20.11.0^..v20.12.0'
-      environment:
-        python_requirements:
-        - aiida-core~=1.0
-        - aiida-quantumespresso~=3.2
-        - aiidalab-widgets-base~=1.0
 scanning_probe:
   releases:
     - url: 'git+https://github.com/nanotech-empa/aiidalab-empa-scanning-probe@master:'

--- a/apps.yaml
+++ b/apps.yaml
@@ -43,7 +43,10 @@ nanoribbons:
         title: Empa nanotech@surfaces Laboratory - Graphene nanoribbons
 quantum-espresso:
   releases:
-    - url: 'git+https://github.com/aiidalab/aiidalab-qe.git@master:v20.11.0^..'
+    - url: 'git+https://github.com/aiidalab/aiidalab-qe.git@master:v22.05.0^..'
+      metadata:
+        state: development
+    - url: 'git+https://github.com/aiidalab/aiidalab-qe.git@master:v20.11.0^..v22.05.0'
       metadata:
         categories:
         - quantum
@@ -60,16 +63,6 @@ quantum-espresso:
         - aiida-core~=1.0
         - aiida-quantumespresso~=3.2
         - aiidalab-widgets-base~=1.0
-      metadata:
-        categories:
-        - quantum
-        logo: https://aiidalab.github.io/aiidalab-qe/miscellaneous/logos/QE.jpg
-        title: Quantum ESPRESSO
-        authors: Carl Simon Adorf, Aliaksandr Yakutovich, Marnik Bercx
-        description: Perform Quantum ESPRESSO calculations
-        external_url: https://github.com/aiidalab/aiidalab-qe
-        documentation_url: https://github.com/aiidalab/aiidalab-qe#readme
-        state: development
 scanning_probe:
   releases:
     - url: 'git+https://github.com/nanotech-empa/aiidalab-empa-scanning-probe@master:'


### PR DESCRIPTION
This is blocked by https://github.com/aiidalab/aiidalab-qe/pull/232.

If I understand correctly @csadorf comment on https://github.com/aiidalab/aiidalab-registry/issues/88#issuecomment-1123738458 about multiple releases of an app, in this PR I remove the duplicate metadata between two previous release. Moreover, I add a concise one for newly released `v22.05.0`. 
