### PR TITLE
Using main and adding support-v23.4.x for legacy support

### DIFF
--- a/apps.yaml
+++ b/apps.yaml
@@ -47,7 +47,8 @@ nanoribbons:
         external_url: https://github.com/nanotech-empa/aiidalab-empa-nanoribbons
 quantum-espresso:
   releases:
-    - url: 'git+https://github.com/aiidalab/aiidalab-qe.git@master:v22.05.0^..'
+    - url: 'git+https://github.com/aiidalab/aiidalab-qe.git@main:v22.05.0^..'
+    - url: 'git+https://github.com/aiidalab/aiidalab-qe.git@support-23.04.x:v23.04.2^..'
 scanning_probe:
   releases:
     - url: 'git+https://github.com/nanotech-empa/aiidalab-empa-scanning-probe@master:v1.8.0^..'


### PR DESCRIPTION
I was proposing to use new way to manage the version release as mentioned in: https://github.com/aiidalab/aiidalab-qe/wiki/Releases-management. 
The goal is that we can keep on making big changes without releasing unstable versions that may affect users. 
The `v23.4.1` is regarded as the stable version before the next stable minor release `v23.10.0`, so any changes that were required to be backported to `v23.4.x` are cherry-picked from `master` (now I change it to `main`) to `support-v23.4.x` and making the release from there.  
However, the catch of adding a new tag to `support-v23.4.x` is the tag will not picked up by the aiidalab registry because the tags and commits are get for a specific branch (see: https://aiidalab.readthedocs.io/en/latest/app_development/publish.html#id6). I think it is a good design to have the tag recognized under the branch. 

The minimal change here is adding tags from branch `support-v23.4.x` to aiidalab-registry. 