### PR TITLE
fetch all tags for legacy support

### DIFF
--- a/apps.yaml
+++ b/apps.yaml
@@ -47,7 +47,7 @@ nanoribbons:
         external_url: https://github.com/nanotech-empa/aiidalab-empa-nanoribbons
 quantum-espresso:
   releases:
-    - url: 'git+https://github.com/aiidalab/aiidalab-qe.git@master:v22.05.0^..'
+    - url: 'git+https://github.com/aiidalab/aiidalab-qe.git@*:v22.05.0^..'
 scanning_probe:
   releases:
     - url: 'git+https://github.com/nanotech-empa/aiidalab-empa-scanning-probe@master:v1.8.0^..'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-aiidalab==22.11.0
+aiidalab==23.3.1
 pre-commit==2.10.1
 packaging<22


### PR DESCRIPTION
After https://github.com/aiidalab/aiidalab/pull/383 (merged and released), this change can be supported.