### PR TITLE
Adding workflow dispatch so the deploy can be triggered manually

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,6 +9,7 @@ on:
       - master
   schedule:
     - cron: 25/20 * * * *
+  workflow_dispatch:
 
 jobs:
   test-and-deploy:

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ $ ./build.sh
 The continuous-integration workflow is implemented with GitHub actions, which runs the pre-commit hooks and tests whether the registry can be built.
 In addition, all commits on the `main` branch are automatically deployed to GitHub pages.
 
+To manually trigger the CI workflow to deploy the registry, go to the [Actions tab](https://github.com/aiidalab/aiidalab-registry/actions) and click on the "Run workflow" button of deploy workflow.
+
 ### Versioning and migrations
 
 * The public registry API specification is maintained under `src/static/api/openapi-v{version}.yaml`.

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ $ ./build.sh
 The continuous-integration workflow is implemented with GitHub actions, which runs the pre-commit hooks and tests whether the registry can be built.
 In addition, all commits on the `main` branch are automatically deployed to GitHub pages.
 
-To manually trigger the CI workflow to deploy the registry, go to the [Actions tab](https://github.com/aiidalab/aiidalab-registry/actions) and click on the "Run workflow" button of deploy workflow.
+To manually trigger the CI workflow to deploy the registry, go to the [Actions tab](https://github.com/aiidalab/aiidalab-registry/actions) and click on the "Run workflow" button of the deploy workflow.
 
 ### Versioning and migrations
 


### PR DESCRIPTION
This allowed the workflow can be triggered manually by developers with write permission https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_dispatch

Sometimes we want to see the change and deployment of registry as soon as possible.