### PR TITLE
Pin aiidalab version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-aiidalab[registry]==24.9.0
+aiidalab[registry]==26.05.2
 pre-commit>=3.6.0


### PR DESCRIPTION
Pinning `aiidalab==26.05.2` to get the new schemas including the new citations field.

<img width="1192" height="467" alt="image" src="https://github.com/user-attachments/assets/a0666011-a9fb-4087-8bfe-98219e9cabaa" />