### PR TITLE
Bump AiiDAlab dependency to 26.06.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-aiidalab[registry]==26.05.2
+aiidalab[registry]==26.06.1
 pre-commit>=3.6.0


### PR DESCRIPTION
26.06.1 includes a fix to the registry schemas.