### PR TITLE
Add quadrupolar-simulator app

### DIFF
--- a/apps.yaml
+++ b/apps.yaml
@@ -120,3 +120,6 @@ lns-app:
 chemshell:
   releases:
     - url: 'git+https://github.com/stfc/aiidalab-chemshell.git@main:v0.1.0^..'
+quadrupolar-simulator:
+  releases:
+    - url: 'git+https://github.com/moritzgubler/aiidaConverseNMR.git@main:'


### PR DESCRIPTION
## Summary
Adds the standalone "Quadrupolar NMR Simulator" AiiDAlab app: an interactive
first/second-order quadrupolar NMR/NQR spectrum simulator (powder and single crystal)
from user-entered Cq (or nu_Q), eta, isotope and magnetic field.

Part of the [aiida-qe-converse](https://github.com/moritzgubler/aiidaConverseNMR)
repo, which also provides aiidalab-qe plugins for computing NMR shielding and EFG
tensors with QE-CONVERSE (registered separately, via aiidalab-qe's own plugin
registry). 

I would like to test this once the compability issues mentioned in https://github.com/aiidalab/aiidalab-qe/pull/1547 have been resolved